### PR TITLE
Implement the PUT route for updates

### DIFF
--- a/app/Http/Controllers/CitationsController.php
+++ b/app/Http/Controllers/CitationsController.php
@@ -152,142 +152,6 @@ class CitationsController extends Controller
         return generateCollectionResponse($type, $citation);
     }
 
-    /**
-     * Deletes either a single citation or deletes all citations for a given
-     * email address. Throws an exception if both the citation ID and the email
-     * query parameter are empty or both are filled. Throws another exception
-     * if there are no citations to delete.
-     *
-     * @param Request $request The request to check for an email address
-     * @param int $id The optional ID of the citation that will be deleted
-     *
-     * @return Response
-     * @throws InvalidRequestException
-     * @throws NoDataException
-     */
-    public function destroy(Request $request, $id=null) {
-        if(empty($id) && !$request->filled('email') && !$request->filled('citations')) {
-            // the route was accessed with no parameter, no email, and directly
-            // via the DELETE method so throw an exception
-            throw new InvalidRequestException(
-                "Please specify either a citation ID, an email address, or an array of citation IDs."
-            );
-        }
-        else if(!empty($id) && $request->filled('email')) {
-            // specifying BOTH an ID and an email address is also a problem
-            // since the idea behind the method is not to handle both cases
-            // at the same time since it could result in a confusing response
-            // to the consuming client
-            throw new InvalidRequestException(
-                "You may only specify either a citation ID or an email address, not both."
-            );
-        }
-        else if($request->filled('citations')) {
-            // we got citation IDs in the DELETE body, so let's validate it first
-            $this->checkRequestTypeJson($request);
-            $this->validate($request, [
-                'citations' => 'array'
-            ]);
-        }
-
-        // PK column that represents the textual IDs of the citations
-        $citationPK = "citation_id";
-
-        // now that our sanity checks are done we can process the actual request
-        // by retrieving the citation (or set of citations) in a specific way
-        if(!empty($id)) {
-            $citations = Citation::wherePartialId($id);
-        }
-        else
-        {
-            // set of citations by user email or set of citations based on the
-            // IDs of the citations in the request body
-            if($request->has('email')) {
-                $email = $request->input('email');
-                $user = User::where('email', $email)->first();
-                if(empty($user)) {
-                    throw new NoDataException(
-                        "The individual with that email address does not exist."
-                    );
-                }
-
-                // resolve the collection based on the ID of the user
-                $citations = Citation::whereHas('members', function($q) use ($user) {
-                    return $q->whereMembersId($user->user_id);
-                });
-            }
-            else if($request->filled('citations')) {
-                // prepend the collection to all of the IDs
-                $ids = array_map(function($v) {
-                    return "citations:{$v}";
-                },
-                $request->input('citations'));
-
-                // resolve the collection based on the IDs
-                $citations = Citation::whereIn($citationPK, $ids);
-            }
-            else
-            {
-                // we received nothing to work with, so treat it as a bad request
-                throw new InvalidRequestException(
-                    "Please specify either a citation ID, an email address, or an array of citation IDs."
-                );
-            }
-        }
-
-        // the get() is intentional even for a single instance because we want
-        // to resolve a Collection so we can use pluck()
-        $citationIds = $citations->get()->pluck('citation_id')->toArray();
-
-        // make sure we have citations
-        if(empty($citationIds)) {
-            throw new NoDataException(
-                "No matching citation(s) to delete."
-            );
-        }
-
-        // we're going to delete the citations in a specific way to prevent the
-        // need to do a separate database call per citation in the case that we
-        // are destroying a set of citations; we will have the same number of
-        // database calls regardless of the number of citations being destroyed
-        try {
-            DB::beginTransaction();
-
-            // delete the various related data in the reverse order of their creation;
-            // we associate the models with their PK that stores the citation ID
-            $ns = "App\\"; // model namespace
-            $models = [
-                'Collection' => $citationPK,
-                'Publisher' => $citationPK,
-                'Document' => $citationPK,
-                'CitationMember' => 'parent_entities_id',
-                'PublishedMetadata' => $citationPK,
-                'CitationMetadata' => $citationPK,
-                'Citation' => $citationPK,
-            ];
-
-            // generate the full model namespace for each model and then delete
-            // all matching data based on the set of citation IDs
-            foreach($models as $modelName => $pk) {
-                $model = "{$ns}{$modelName}";
-                $model::whereIn($pk, $citationIds)->delete();
-            }
-          
-            DB::commit();
-        }
-        catch(\Exception $e) {
-            DB::rollBack();
-            Log::error('Could not delete citation(s): [' .
-                implode(",", $citationIds) . "]. " . $e->getMessage());
-            return generateErrorResponse('The citation(s) could not be deleted', 500);
-        }
-
-        // return the success response
-        return generateMessageResponse(
-            count($citationIds) . " citation(s) were deleted successfully!"
-        );
-    }
-            
     /*
      * Processes a citation creation request. The data is expected to be JSON.
      *
@@ -468,6 +332,142 @@ class CitationsController extends Controller
 
         // return the success response
         return generateMessageResponse('The citation has been updated successfully');
+    }
+
+    /**
+     * Deletes either a single citation or deletes all citations for a given
+     * email address. Throws an exception if both the citation ID and the email
+     * query parameter are empty or both are filled. Throws another exception
+     * if there are no citations to delete.
+     *
+     * @param Request $request The request to check for an email address
+     * @param int $id The optional ID of the citation that will be deleted
+     *
+     * @return Response
+     * @throws InvalidRequestException
+     * @throws NoDataException
+     */
+    public function destroy(Request $request, $id=null) {
+        if(empty($id) && !$request->filled('email') && !$request->filled('citations')) {
+            // the route was accessed with no parameter, no email, and directly
+            // via the DELETE method so throw an exception
+            throw new InvalidRequestException(
+                "Please specify either a citation ID, an email address, or an array of citation IDs."
+            );
+        }
+        else if(!empty($id) && $request->filled('email')) {
+            // specifying BOTH an ID and an email address is also a problem
+            // since the idea behind the method is not to handle both cases
+            // at the same time since it could result in a confusing response
+            // to the consuming client
+            throw new InvalidRequestException(
+                "You may only specify either a citation ID or an email address, not both."
+            );
+        }
+        else if($request->filled('citations')) {
+            // we got citation IDs in the DELETE body, so let's validate it first
+            $this->checkRequestTypeJson($request);
+            $this->validate($request, [
+                'citations' => 'array'
+            ]);
+        }
+
+        // PK column that represents the textual IDs of the citations
+        $citationPK = "citation_id";
+
+        // now that our sanity checks are done we can process the actual request
+        // by retrieving the citation (or set of citations) in a specific way
+        if(!empty($id)) {
+            $citations = Citation::wherePartialId($id);
+        }
+        else
+        {
+            // set of citations by user email or set of citations based on the
+            // IDs of the citations in the request body
+            if($request->has('email')) {
+                $email = $request->input('email');
+                $user = User::where('email', $email)->first();
+                if(empty($user)) {
+                    throw new NoDataException(
+                        "The individual with that email address does not exist."
+                    );
+                }
+
+                // resolve the collection based on the ID of the user
+                $citations = Citation::whereHas('members', function($q) use ($user) {
+                    return $q->whereMembersId($user->user_id);
+                });
+            }
+            else if($request->filled('citations')) {
+                // prepend the collection to all of the IDs
+                $ids = array_map(function($v) {
+                    return "citations:{$v}";
+                },
+                $request->input('citations'));
+
+                // resolve the collection based on the IDs
+                $citations = Citation::whereIn($citationPK, $ids);
+            }
+            else
+            {
+                // we received nothing to work with, so treat it as a bad request
+                throw new InvalidRequestException(
+                    "Please specify either a citation ID, an email address, or an array of citation IDs."
+                );
+            }
+        }
+
+        // the get() is intentional even for a single instance because we want
+        // to resolve a Collection so we can use pluck()
+        $citationIds = $citations->get()->pluck('citation_id')->toArray();
+
+        // make sure we have citations
+        if(empty($citationIds)) {
+            throw new NoDataException(
+                "No matching citation(s) to delete."
+            );
+        }
+
+        // we're going to delete the citations in a specific way to prevent the
+        // need to do a separate database call per citation in the case that we
+        // are destroying a set of citations; we will have the same number of
+        // database calls regardless of the number of citations being destroyed
+        try {
+            DB::beginTransaction();
+
+            // delete the various related data in the reverse order of their creation;
+            // we associate the models with their PK that stores the citation ID
+            $ns = "App\\"; // model namespace
+            $models = [
+                'Collection' => $citationPK,
+                'Publisher' => $citationPK,
+                'Document' => $citationPK,
+                'CitationMember' => 'parent_entities_id',
+                'PublishedMetadata' => $citationPK,
+                'CitationMetadata' => $citationPK,
+                'Citation' => $citationPK,
+            ];
+
+            // generate the full model namespace for each model and then delete
+            // all matching data based on the set of citation IDs
+            foreach($models as $modelName => $pk) {
+                $model = "{$ns}{$modelName}";
+                $model::whereIn($pk, $citationIds)->delete();
+            }
+          
+            DB::commit();
+        }
+        catch(\Exception $e) {
+            DB::rollBack();
+            Log::error('Could not delete citation(s): [' .
+                implode(",", $citationIds) . "]. " . $e->getMessage());
+            return generateErrorResponse('The citation(s) could not be deleted', 500);
+        }
+
+        // return the success response
+        return generateMessageResponse(
+            count($citationIds) . " citation(s) were deleted successfully!"
+        );
     }
 
     /**

--- a/app/Http/Controllers/CitationsController.php
+++ b/app/Http/Controllers/CitationsController.php
@@ -94,6 +94,8 @@ class CitationsController extends Controller
      *
      * @param Request $request The request to process
      * @return Response
+     *
+     * @throws InvalidPayloadTypeException
      */
     public function store(Request $request) {
         // ensure this is a JSON request
@@ -209,6 +211,21 @@ class CitationsController extends Controller
 
         // return the success response
         return generateMessageResponse('The citation has been added successfully');
+    }
+
+    /**
+     * Processes a citation update request. The data is expected to be JSON.
+     *
+     * @param Request $request The request to process
+     * @param int $id The ID of the citation to update
+     *
+     * @return Response
+     *
+     * @throws InvalidPayloadTypeException
+     */
+    public function update(Request $request, $id) {
+        // ensure this is a JSON request
+        $this->checkRequestTypeJson($request);
     }
 
     /**

--- a/app/Http/Controllers/CitationsController.php
+++ b/app/Http/Controllers/CitationsController.php
@@ -203,7 +203,8 @@ class CitationsController extends Controller
         }
         catch(\Exception $e) {
             DB::rollBack();
-            Log::error('Could not create citation: ' . $e->getMessage());
+            Log::error('Could not create citation: ' . $e->getMessage() .
+                '\n' . $e->getTraceAsString());
             return generateErrorResponse(
                 'The citation could not be created', 500, false
             );
@@ -226,6 +227,27 @@ class CitationsController extends Controller
     public function update(Request $request, $id) {
         // ensure this is a JSON request
         $this->checkRequestTypeJson($request);
+
+        // we have to be incredibly careful with the JSON body since we don't
+        // want to delete data accidentally by nature of it merely not being
+        // present in the request
+
+        try {
+            DB::beginTransaction();
+
+            DB::commit();
+        }
+        catch(\Exception $e) {
+            DB::rollBack();
+            Log::error('Could not update citation: ' . $e->getMessage() .
+                '\n' . $e->getTraceAsString());
+            return generateErrorResponse(
+                'The citation could not be updated', 500, false
+            );
+        }
+
+        // return the success response
+        return generateMessageResponse('The citation has been updated successfully');
     }
 
     /**

--- a/app/Http/Controllers/CitationsController.php
+++ b/app/Http/Controllers/CitationsController.php
@@ -307,7 +307,7 @@ class CitationsController extends Controller
         else
         {
             throw new InvalidRequestException(
-                'Please specify valid data to be modified'
+                'Please specify valid data to be modified.'
             );
         }
 
@@ -503,7 +503,7 @@ class CitationsController extends Controller
         $basicDataRule = "string|nullable"; // string type but can also be null
 
         $rules = [];
-        $input = [];
+        $input = []; // this is a multidimensional associative array as well
 
         // ensure the type is within the acceptable set of citation types if
         // it has been provided
@@ -570,7 +570,7 @@ class CitationsController extends Controller
                     foreach($value as $attribute) {
                         if($request->has("{$key}.{$attribute}")) {
                             $rules["{$key}.{$attribute}"] = $basicDataRule;
-                            $input["{$key}.{$attribute}"] = $request->input("{$key}.{$attribute}");
+                            $input[$key][$attribute] = $request->input("{$key}.{$attribute}");
                         }
                     }
                 }

--- a/app/Http/Controllers/CitationsController.php
+++ b/app/Http/Controllers/CitationsController.php
@@ -306,7 +306,9 @@ class CitationsController extends Controller
         }
         else
         {
-            // TODO: throw InvalidRequestException here (wait until DELETE pull request gets merged)
+            throw new InvalidRequestException(
+                'Please specify valid data to be modified'
+            );
         }
 
         // we have to be incredibly careful with the JSON body since we don't

--- a/app/Http/Controllers/CitationsController.php
+++ b/app/Http/Controllers/CitationsController.php
@@ -332,7 +332,6 @@ class CitationsController extends Controller
         // present in the request; we also want to be able to load different
         // relationships conditionally so we're not loading everything if only
         // a few basic fields are being updated.
-        $objects = [];
         try {
             DB::beginTransaction();
 

--- a/app/Http/Controllers/CitationsController.php
+++ b/app/Http/Controllers/CitationsController.php
@@ -174,7 +174,7 @@ class CitationsController extends Controller
 
         // now we need to validate the minimum data in the payload
         $this->validate($request, [
-            'type' => 'required|in:' . implode(',' $this->citationTypes),
+            'type' => 'required|in:' . implode(',', $this->citationTypes),
             "{$metaKey}.title" => 'required',
             "{$pubMetaKey}.date" => 'required',
             "{$membersKey}" => 'required|array|min:1',

--- a/app/Http/Controllers/CitationsController.php
+++ b/app/Http/Controllers/CitationsController.php
@@ -30,7 +30,7 @@ class CitationsController extends Controller
      *
      * @var string
      */
-    protected $pubMetaKey = "published_metadata";
+    protected $pubMetaKey = "published";
 
     /**
      * This is the key of the author membership sub-object that may appear

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,14 +24,14 @@ $router->group(['prefix' => '1.0'], function () use ($router) {
     	'as' => 'citations.store',
     	'uses' => 'CitationsController@store',
     ]);
+    $router->put('citations/{id:[0-9]+}', [
+        'as' => 'citations.update',
+        'uses' => 'CitationsController@update',
+    ]);
     // this DELETE route handles both the single deletion case as well as
     // the case where an email will be provided as part of the query string
     $router->delete('citations[/{id:[0-9]+}]', [
         'as' => 'citations.destroy',
         'uses' => 'CitationsController@destroy'
-    ]);
-    $router->put('citations/{id:[0-9]+}', [
-        'as' => 'citations.update',
-        'uses' => 'CitationsController@update',
     ]);
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,4 +24,8 @@ $router->group(['prefix' => '1.0'], function () use ($router) {
     	'as' => 'citations.store',
     	'uses' => 'CitationsController@store',
     ]);
+    $router->put('citations/{id:[0-9]+}', [
+        'as' => 'citations.update',
+        'uses' => 'CitationsController@update',
+    ]);
 });


### PR DESCRIPTION
This PR implements the update functionality for the web service. This is a bit interesting since the idea of the WS is to provide the driving engine for a visual citation manager.

In doing so, the update functionality can both perform updates and inserts based upon the state of the citations database and the content of the JSON request payload. If there is a sub-object key in the JSON payload that does not exist as a relationship's model instance the instance will be created; otherwise, the instance will be updated. We also have the ability to modify the base attributes of the citation model itself; this is all determined based upon how the `generateUpdateValidationRulesAndInput()` method returns its data.

The actual relationship names and the content to update/insert is all driven dynamically by arrays and loops.

Here's an example JSON payload that would touch the relevant parts of the citations database:

```
{
	"document": {
		"url": "Some URL"
	},
	"collection": {
		"number": "5"
	},
	"metadata": {
		"title": "This book is different"
	},
	"publisher": {
		"organization": "Incorporation Incorporated"
	},
	"published": {
		"date": "2018"	
	},
	"note": "This is a note"
}
```
You can remove different records in different tables and then watch as the `update()` method re-creates them appropriately based upon the keys in the request payload.

Also, the set of modifications in the files is larger than it would otherwise be since I did some code reorganization in this branch as well.