### PR TITLE
Add routes for member management (POST and DELETE)

### DIFF
--- a/app/Http/Controllers/CitationsController.php
+++ b/app/Http/Controllers/CitationsController.php
@@ -509,7 +509,8 @@ class CitationsController extends Controller
         catch(\Exception $e) {
             DB::rollBack();
             Log::error('Could not delete citation(s): [' .
-                implode(",", $citationIds) . "]. " . $e->getMessage());
+                implode(",", $citationIds) . "]. " . $e->getMessage() .
+                '\n' . $e->getTraceAsString());
             return generateErrorResponse('The citation(s) could not be deleted', 500);
         }
 
@@ -563,7 +564,8 @@ class CitationsController extends Controller
         catch(\Exception $e) {
             DB::rollBack();
             Log::error("Could not add member(s) to citation {$id}: [" .
-                implode(",", array_keys($people)) . "]. " . $e->getMessage());
+                implode(",", array_keys($people)) . "]. " . $e->getMessage() .
+                '\n' . $e->getTraceAsString());
             return generateErrorResponse('Could not add ' . count($people) .
                 ' member(s) to the citation', 500);
         }

--- a/app/Http/Controllers/CitationsController.php
+++ b/app/Http/Controllers/CitationsController.php
@@ -267,8 +267,7 @@ class CitationsController extends Controller
         }
         catch(\Exception $e) {
             DB::rollBack();
-            Log::error('Could not create citation: ' . $e->getMessage() .
-                '\n' . $e->getTraceAsString());
+            logErrorException('Could not create citation.', $e);
             return generateErrorResponse(
                 'The citation could not be created', 500, false
             );
@@ -372,8 +371,7 @@ class CitationsController extends Controller
         }
         catch(\Exception $e) {
             DB::rollBack();
-            Log::error('Could not update citation: ' . $e->getMessage() .
-                '\n' . $e->getTraceAsString());
+            logErrorException('Could not update citation.', $e);
             return generateErrorResponse(
                 'The citation could not be updated', 500, false
             );
@@ -508,9 +506,8 @@ class CitationsController extends Controller
         }
         catch(\Exception $e) {
             DB::rollBack();
-            Log::error('Could not delete citation(s): [' .
-                implode(",", $citationIds) . "]. " . $e->getMessage() .
-                '\n' . $e->getTraceAsString());
+            logErrorException('Could not delete citation(s): [' .
+                implode(",", $citationIds) . "].", $e);
             return generateErrorResponse('The citation(s) could not be deleted', 500);
         }
 
@@ -563,9 +560,8 @@ class CitationsController extends Controller
         }
         catch(\Exception $e) {
             DB::rollBack();
-            Log::error("Could not add member(s) to citation {$id}: [" .
-                implode(",", array_keys($people)) . "]. " . $e->getMessage() .
-                '\n' . $e->getTraceAsString());
+            logErrorException("Could not add member(s) to citation {$id}: [" .
+                implode(",", array_keys($people)) . "].", $e);
             return generateErrorResponse('Could not add ' . count($people) .
                 ' member(s) to the citation', 500);
         }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,8 +1,5 @@
 <?php
 
-use Exception;
-use Log;
-
 /**
  * Generates a response array based upon a given static message as well as an
  * optional response code and optional success value.
@@ -115,9 +112,9 @@ function fixCitationAttributes(&$citation) {
  * Logs an error that resulted in an exception being raised.
  *
  * @param string $message A descriptive (non-exception) error message
- * @param Exception $exception The exception that was raised
+ * @param Exception $e The exception that was raised
  */
-function logErrorException($message, Exception $exception) {
+function logErrorException($message, Exception $e) {
 	Log::error($message . " " . $e->getMessage() .
         '\n' . $e->getTraceAsString());
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,5 +1,7 @@
 <?php
 
+use Log;
+
 /**
  * Generates a response array based upon a given static message as well as an
  * optional response code and optional success value.
@@ -106,4 +108,15 @@ function fixCitationAttributes(&$citation) {
 	$citation['is_published'] = ($citation['wasPublished'] ? "true" : "false");
 
 	return $citation;
+}
+
+/**
+ * Logs an error that resulted in an exception being raised.
+ *
+ * @param string $message A descriptive (non-exception) error message
+ * @param Exception $exception The exception that was raised
+ */
+function logErrorException($message, $exception) {
+	Log::error($message . " " . $e->getMessage() .
+        '\n' . $e->getTraceAsString());
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,5 +1,6 @@
 <?php
 
+use Exception;
 use Log;
 
 /**
@@ -116,7 +117,7 @@ function fixCitationAttributes(&$citation) {
  * @param string $message A descriptive (non-exception) error message
  * @param Exception $exception The exception that was raised
  */
-function logErrorException($message, $exception) {
+function logErrorException($message, Exception $exception) {
 	Log::error($message . " " . $e->getMessage() .
         '\n' . $e->getTraceAsString());
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,14 @@ $router->group(['prefix' => '1.0'], function () use ($router) {
     	'as' => 'citations.store',
     	'uses' => 'CitationsController@store',
     ]);
+    $router->post('citations/{id:[0-9]+}/members', [
+        'as' => 'citations.members.store',
+        'uses' => 'CitationsController@addMember',
+    ]);
+    $router->delete('citations/{id:[0-9]+}/members', [
+        'as' => 'citations.members.destroy',
+        'uses' => 'CitationsController@destroyMember',
+    ]);
     $router->put('citations/{id:[0-9]+}', [
         'as' => 'citations.update',
         'uses' => 'CitationsController@update',


### PR DESCRIPTION
There are now two more routes so we now have member management.

### Adding Members to a Citation
`/1.0/citations/[citation ID]/members` over `POST`

Here's a sample JSON body you can use to associate multiple individuals with a single citation (the individuals are Jeff and Nerces):

```
{
   "members": [
   {
      "user_id": "members:000261191",
      "precedence": "2"
   },
   {
      "user_id": "members:000420312",
      "precedence": "3"
   }
   ]
}
```

### Removing Members from a Citation
`/1.0/citations/[citation ID]/members` over `DELETE`

Here's a sample JSON body you can use to unassociate multiple individuals from a single citation (the individuals are Jeff and Nerces):

```
{
   "members": [
   {
      "user_id": "members:000261191"
   },
   {
      "user_id": "members:000420312"
   }
   ]
}
```