### PR TITLE
Add API Key Authorization

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -10,9 +10,13 @@ use Laravel\Lumen\Exceptions\Handler as ExceptionHandler;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
+use App\Exceptions\InvalidApiKeyException;
 use App\Exceptions\InvalidPayloadTypeException;
 use App\Exceptions\InvalidRequestException;
+use App\Exceptions\MissingApiKeyException;
+use App\Exceptions\MissingRouteNameException;
 use App\Exceptions\NoDataException;
+use App\Exceptions\PermissionDeniedException;
 
 class Handler extends ExceptionHandler
 {
@@ -86,6 +90,34 @@ class Handler extends ExceptionHandler
                 $e->getMessage(),
                 404
             ), 404);
+        }
+        else if($e instanceof InvalidApiKeyException) {
+            return response(generateErrorResponse(
+                $request,
+                'You must supply a valid active API key for that action',
+                400
+            ), 400);
+        }
+        else if($e instanceof MissingApiKeyException) {
+            return response(generateErrorResponse(
+                $request,
+                'The X-API-Key header was missing from your request',
+                400
+            ), 400);
+        }
+        else if($e instanceof MissingRouteNameException) {
+            return response(generateErrorResponse(
+                $request,
+                'Unable to resolve the permission associated with that action',
+                500
+            ), 500);
+        }
+        else if($e instanceof PermissionDeniedException) {
+            return response(generateErrorResponse(
+                $request,
+                'You are not authorized to perform that action',
+                403
+            ), 403);
         }
 
         return parent::render($request, $e);

--- a/app/Exceptions/InvalidApiKeyException.php
+++ b/app/Exceptions/InvalidApiKeyException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Exceptions;
+use Exception;
+
+class InvalidApiKeyException extends Exception
+{
+	/**
+	 * Constructs a new InvalidApiKeyException instance.
+	 *
+	 * @param string $message Optional message for the exception
+	 */
+	public function __construct($message="") {
+		parent::__construct($message);
+	}
+}

--- a/app/Exceptions/MissingApiKeyException.php
+++ b/app/Exceptions/MissingApiKeyException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Exceptions;
+use Exception;
+
+class MissingApiKeyException extends Exception
+{
+	/**
+	 * Constructs a new MissingApiKeyException instance.
+	 *
+	 * @param string $message Optional message for the exception
+	 */
+	public function __construct($message="") {
+		parent::__construct($message);
+	}
+}

--- a/app/Exceptions/MissingRouteNameException.php
+++ b/app/Exceptions/MissingRouteNameException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Exceptions;
+use Exception;
+
+class MissingRouteNameException extends Exception
+{
+	/**
+	 * Constructs a new MissingRouteNameException instance.
+	 *
+	 * @param string $message Optional message for the exception
+	 */
+	public function __construct($message="") {
+		parent::__construct($message);
+	}
+}

--- a/app/Exceptions/PermissionDeniedException.php
+++ b/app/Exceptions/PermissionDeniedException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Exceptions;
+use Exception;
+
+class PermissionDeniedException extends Exception
+{
+	/**
+	 * Constructs a new PermissionDeniedException instance.
+	 *
+	 * @param string $message Optional message for the exception
+	 */
+	public function __construct($message="") {
+		parent::__construct($message);
+	}
+}

--- a/app/Http/Middleware/APIAuthorization.php
+++ b/app/Http/Middleware/APIAuthorization.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use App\ApiKey;
+
+use App\Exceptions\InvalidApiKeyException;
+use App\Exceptions\MissingApiKeyException;
+use App\Exceptions\MissingRouteNameException;
+use App\Exceptions\PermissionDeniedException;
+
+class APIAuthorization
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  string|null  $guard
+     * @return mixed
+     */
+    public function handle($request, Closure $next, $guard = null)
+    {
+        // resolve the current route and its name since we will be using that
+        // for authorization and permission checks
+        $route = $request->route();
+        $routeConf = (!empty($route[1]) ? $route[1] : null);
+        $routeName = '';
+        if(!empty($routeConf)) {
+            $routeName = (!empty($routeConf['as']) ? $routeConf['as'] : '');
+        }
+
+        // if we have a route name, we can check permissions based upon the
+        // given X-API-Key request header
+        if(!empty($routeName)) {
+            $keyValue = $request->headers->get('X-API-Key');
+
+            // an API key is NOT required for public-facing (*.index, *.show)
+            // routes since they're public information; everything else needs
+            // to be checked
+            if(!empty($keyValue)) {
+                // load up the key and ensure it exists
+                $key = ApiKey::with('scopes.permissions')
+                    ->whereKey($keyValue)
+                    ->whereActive()
+                    ->first();
+
+                // if we have a valid key, then check the scopes/permissions;
+                // otherwise, render a JSON error response
+                if(!empty($key)) {
+                    // if we have a scope with the proper permission, we are
+                    // good; otherwise, throw an exception
+                    if($key->hasPermission($routeName)) {
+                        return $next($request);
+                    }
+
+                    // API key not authorized to perform that action
+                    throw new PermissionDeniedException();
+                }
+
+                // the supplied header value does not match a valid API key
+                throw new InvalidApiKeyException();
+            }
+            else
+            {
+                // if the route name ends with .index or .show then we can still
+                // proceed without an API key; otherwise we NEED an API key
+                if(ends_with($routeName, '.index') || ends_with($routeName, '.show')) {
+                    return $next($request);
+                }
+
+                // the API key was missing from the request
+                throw new MissingApiKeyException();
+            }
+        }
+
+        // the request is NOT authorized to proceed (unnamed route)
+        throw new MissingRouteNameException();
+    }
+}

--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -20,6 +20,50 @@ class ApiKey extends Model
 	}
 
 	/**
+	 * Query scope to limit returned results only to API keys that are actually
+	 * active.
+	 *
+	 * @param Builder $query
+	 * @return Builder
+	 */
+	public function scopeWhereActive($query) {
+		return $query->where('active', '1');
+	}
+
+	/**
+	 * Query scope to limit returned results only to the given API key value.
+	 *
+	 * @param Builder $query
+	 * @param string $key The value of the API key
+	 *
+	 * @return Builder
+	 */
+	public function scopeWhereKey($query, $key) {
+		return $query->where('key', $key);
+	}
+
+	/**
+	 * Returns whether any of the scopes associated with this API key grant the
+	 * given permission name to the key.
+	 *
+	 * @param string $permission Name of the permission to check
+	 * @return bool
+	 */
+	public function hasPermission($permission) {
+		if(!isset($this->scopes)) {
+			$this->load('scopes');
+		}
+
+		foreach($this->scopes as $scope) {
+			if($scope->hasPermission($permission) || $scope->hasAllPermissions()) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Returns whether this key is active for this service.
 	 *
 	 * @return bool

--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -26,7 +26,7 @@ class ApiKey extends Model
 	 * @param Builder $query
 	 * @return Builder
 	 */
-	public function scopeWhereActive($query) {
+	public function scopeWhereIsActive($query) {
 		return $query->where('active', '1');
 	}
 
@@ -38,7 +38,7 @@ class ApiKey extends Model
 	 *
 	 * @return Builder
 	 */
-	public function scopeWhereKey($query, $key) {
+	public function scopeWhereKeyValue($query, $key) {
 		return $query->where('key', $key);
 	}
 

--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ApiKey extends Model
+{
+	protected $table = "keys";
+	protected $primaryKey = "key_id";
+
+	/**
+	 * Returns a BelongsToMany instance representing the set of scopes that this
+	 * key has been authorized to use.
+	 *
+	 * @return BelongsToMany
+	 */
+	public function scopes() {
+		return $this->belongsToMany('App\ApiScope', 'key_scope', 'scope', 'key_id');
+	}
+
+	/**
+	 * Returns whether this key is active for this service.
+	 *
+	 * @return bool
+	 */
+	public function isActive() {
+		return (bool)$this->active;
+	}
+}

--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -16,7 +16,7 @@ class ApiKey extends Model
 	 * @return BelongsToMany
 	 */
 	public function scopes() {
-		return $this->belongsToMany('App\ApiScope', 'key_scope', 'scope', 'key_id');
+		return $this->belongsToMany('App\ApiScope', 'key_scope', 'key_id', 'scope');
 	}
 
 	/**

--- a/app/Models/ApiPermission.php
+++ b/app/Models/ApiPermission.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ApiPermission extends Model
+{
+	protected $table = "permissions";
+	protected $primaryKey = "system_name";
+	public $incrementing = false;
+}

--- a/app/Models/ApiScope.php
+++ b/app/Models/ApiScope.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ApiScope extends Model
+{
+	protected $table = "scopes";
+	protected $primaryKey = "system_name";
+	public $incrementing = false;
+
+	/**
+	 * Returns a BelongsToMany instance representing the set of permissions
+	 * associated with this scope.
+	 *
+	 * @return BelongsToMany
+	 */
+	public function permissions() {
+		return $this->belongsToMany('App\ApiPermission', 'permission_scope', 'permission', 'scope');
+	}
+
+	/**
+	 * Returns whether this scope has a specific permission.
+	 *
+	 * @param string $permission The system name of the permission to check
+	 * @return bool
+	 */
+	public function hasPermission($permission) {
+		// if the scope is "all" then we can do anything
+		if($this->system_name == 'all') {
+			return true;
+		}
+
+		if(!isset($this->permissions)) {
+			$this->load('permissions');
+		}
+
+		foreach($this->permissions as $permission) {
+			if($permission->system_name == $permission) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/app/Models/ApiScope.php
+++ b/app/Models/ApiScope.php
@@ -17,7 +17,7 @@ class ApiScope extends Model
 	 * @return BelongsToMany
 	 */
 	public function permissions() {
-		return $this->belongsToMany('App\ApiPermission', 'permission_scope', 'permission', 'scope');
+		return $this->belongsToMany('App\ApiPermission', 'permission_scope', 'scope', 'permission');
 	}
 
 	/**

--- a/app/Models/ApiScope.php
+++ b/app/Models/ApiScope.php
@@ -45,8 +45,8 @@ class ApiScope extends Model
 			$this->load('permissions');
 		}
 
-		foreach($this->permissions as $permission) {
-			if($permission->system_name == $permission) {
+		foreach($this->permissions as $permissionObj) {
+			if($permissionObj->system_name == $permission) {
 				return true;
 			}
 		}

--- a/app/Models/ApiScope.php
+++ b/app/Models/ApiScope.php
@@ -21,6 +21,15 @@ class ApiScope extends Model
 	}
 
 	/**
+	 * Returns whether this scope has all possible permissions.
+	 *
+	 * @return bool
+	 */
+	public function hasAllPermissions() {
+		return $this->system_name == 'all';
+	}
+
+	/**
 	 * Returns whether this scope has a specific permission.
 	 *
 	 * @param string $permission The system name of the permission to check
@@ -28,7 +37,7 @@ class ApiScope extends Model
 	 */
 	public function hasPermission($permission) {
 		// if the scope is "all" then we can do anything
-		if($this->system_name == 'all') {
+		if($this->hasAllPermissions()) {
 			return true;
 		}
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class User extends Model
 {
-	protected $table = "citations_ws.users";
+	protected $table = "users";
 	protected $primaryKey = "user_id";
 	public $incrementing = false;
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -72,6 +72,10 @@ $app->middleware([
    App\Http\Middleware\APIVersioning::class,
 ]);
 
+$app->routeMiddleware([
+    'api_auth' => App\Http\Middleware\APIAuthorization::class,
+]);
+
 /*
 |--------------------------------------------------------------------------
 | Register Service Providers
@@ -113,7 +117,8 @@ $app->router->group([
 // v1.0
 $app->router->group([
     'namespace' => 'App\Http\Controllers',
-    'prefix' => '1.0'
+    'prefix' => '1.0',
+    'middleware' => 'api_auth',
 ], function ($router) {
     require __DIR__.'/../routes/1.0.php';
 });
@@ -121,7 +126,8 @@ $app->router->group([
 // v1.1
 $app->router->group([
     'namespace' => 'App\Http\Controllers',
-    'prefix' => '1.1'
+    'prefix' => '1.1',
+    'middleware' => 'api_auth',
 ], function ($router) {
     require __DIR__.'/../routes/1.1.php';
 });

--- a/database/migrations/2018_06_08_101534_create_keys_table.php
+++ b/database/migrations/2018_06_08_101534_create_keys_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateKeysTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('keys', function (Blueprint $table) {
+            $table->increments('key_id');
+            $table->string('key', 128)->unique();
+            $table->boolean('active')->default(true);
+            
+            $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at')->nullable()->default(NULL);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('keys');
+    }
+}

--- a/database/migrations/2018_06_08_101540_create_permission_scope_table.php
+++ b/database/migrations/2018_06_08_101540_create_permission_scope_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreatePermissionScopeTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('permission_scope', function (Blueprint $table) {
+            $table->string('scope', 128);
+            $table->string('permission', 128);
+            $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at')->nullable()->default(NULL);
+            
+            $table->primary(['scope', 'permission']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('permission_scope');
+    }
+}

--- a/database/migrations/2018_06_08_102511_create_permissions_table.php
+++ b/database/migrations/2018_06_08_102511_create_permissions_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreatePermissionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('permissions', function (Blueprint $table) {
+            $table->string('system_name', 32);
+            $table->string('display_name', 64);
+            $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at')->nullable()->default(NULL);
+            
+            $table->primary('system_name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('permissions');
+    }
+}

--- a/database/migrations/2018_06_08_103012_create_scopes_table.php
+++ b/database/migrations/2018_06_08_103012_create_scopes_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateScopesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('scopes', function (Blueprint $table) {
+            $table->string('system_name', 32);
+            $table->string('display_name', 64);
+            $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at')->nullable()->default(NULL);
+            
+            $table->primary('system_name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('scopes');
+    }
+}

--- a/database/migrations/2018_06_08_103835_create_key_scope_table.php
+++ b/database/migrations/2018_06_08_103835_create_key_scope_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateKeyScopeTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('key_scope', function (Blueprint $table) {
+            $table->integer('key_id');
+            $table->string('scope', 32);
+            $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at')->nullable()->default(NULL);
+            
+            $table->primary(['key_id', 'scope']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('key_scope');
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -16,6 +16,6 @@ class DatabaseSeeder extends Seeder
         $this->call('PermissionScopeTableSeeder');
 
         // un-comment this to generate three API keys
-        $this->call('KeysTableSeeder');
+        //$this->call('KeysTableSeeder');
     }
 }

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -14,5 +14,8 @@ class DatabaseSeeder extends Seeder
     	$this->call('PermissionsTableSeeder');
         $this->call('ScopesTableSeeder');
         $this->call('PermissionScopeTableSeeder');
+
+        // un-comment this to generate three API keys
+        $this->call('KeysTableSeeder');
     }
 }

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,6 +11,8 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call('UsersTableSeeder');
+    	$this->call('PermissionsTableSeeder');
+        $this->call('ScopesTableSeeder');
+        $this->call('PermissionScopeTableSeeder');
     }
 }

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -15,7 +15,8 @@ class DatabaseSeeder extends Seeder
         $this->call('ScopesTableSeeder');
         $this->call('PermissionScopeTableSeeder');
 
-        // un-comment this to generate three API keys
+        // un-comment this to replace the keys table and its associated
+        // pivot table values with three new API keys
         //$this->call('KeysTableSeeder');
     }
 }

--- a/database/seeds/KeysTableSeeder.php
+++ b/database/seeds/KeysTableSeeder.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use App\ApiKey;
+
+class KeysTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $table = (new ApiKey())->getTable();
+        DB::table($table)->delete();
+
+        // key with all scopes
+        $allKey = ApiKey::create([
+            'key' => sha1(bin2hex(random_bytes(5))),
+        ]);
+        $allKey->scopes()->attach('all');
+
+        // key with "import-scopus" scope
+        $importKey = ApiKey::create([
+            'key' => sha1(bin2hex(random_bytes(5))),
+        ]);
+        $importKey->scopes()->attach('import-scopus');
+
+        // key with "manipulate" scope
+        $manipulateKey = ApiKey::create([
+            'key' => sha1(bin2hex(random_bytes(5))),
+        ]);
+        $manipulateKey->scopes()->attach('manipulate');
+    }
+}

--- a/database/seeds/KeysTableSeeder.php
+++ b/database/seeds/KeysTableSeeder.php
@@ -15,7 +15,7 @@ class KeysTableSeeder extends Seeder
         // THIS SEEDER SHOULD ONLY BE RUN DURING DEVELOPMENT AND TO GENERATE
         // AN INITIAL SET OF API KEYS; THIS SEEDER DESTROYS DATA BEFORE IT
         // RE-CREATES IT
-        
+
         $table = (new ApiKey())->getTable();
         $scopePivotTable = 'key_scope';
         DB::table($table)->delete();
@@ -31,12 +31,12 @@ class KeysTableSeeder extends Seeder
         $importKey = ApiKey::create([
             'key' => sha1(bin2hex(random_bytes(5))),
         ]);
-        $importKey->scopes()->attach('import-scopus');
+        $importKey->scopes()->attach('citations.import.scopus');
 
         // key with "manipulate" scope
         $manipulateKey = ApiKey::create([
             'key' => sha1(bin2hex(random_bytes(5))),
         ]);
-        $manipulateKey->scopes()->attach('manipulate');
+        $manipulateKey->scopes()->attach('citations.manipulate');
     }
 }

--- a/database/seeds/KeysTableSeeder.php
+++ b/database/seeds/KeysTableSeeder.php
@@ -12,8 +12,14 @@ class KeysTableSeeder extends Seeder
      */
     public function run()
     {
+        // THIS SEEDER SHOULD ONLY BE RUN DURING DEVELOPMENT AND TO GENERATE
+        // AN INITIAL SET OF API KEYS; THIS SEEDER DESTROYS DATA BEFORE IT
+        // RE-CREATES IT
+        
         $table = (new ApiKey())->getTable();
+        $scopePivotTable = 'key_scope';
         DB::table($table)->delete();
+        DB::table($scopePivotTable)->delete();
 
         // key with all scopes
         $allKey = ApiKey::create([

--- a/database/seeds/PermissionScopeTableSeeder.php
+++ b/database/seeds/PermissionScopeTableSeeder.php
@@ -16,35 +16,35 @@ class PermissionScopeTableSeeder extends Seeder
 
         DB::table($table)->delete();
         DB::table($table)->insert([
-            // "import-scopus" scope includes all Scopus import permissions
+            // "import.scopus" scope includes all Scopus import permissions
         	[
-        		'scope' => 'import-scopus',
+        		'scope' => 'citations.import.scopus',
         		'permission' => 'citations.import.orcid',
         	],
             [
-                'scope' => 'import-scopus',
+                'scope' => 'citations.import.scopus',
                 'permission' => 'citations.import.author',
             ],
 
-            // "manipulate" scope includes all citation manipulation permissions
+            // "citations.manipulate" scope includes all citation manipulation permissions
             [
-                'scope' => 'manipulate',
+                'scope' => 'citations.manipulate',
                 'permission' => 'citations.store',
             ],
             [
-                'scope' => 'manipulate',
+                'scope' => 'citations.manipulate',
                 'permission' => 'citations.update',
             ],
             [
-                'scope' => 'manipulate',
+                'scope' => 'citations.manipulate',
                 'permission' => 'citations.destroy',
             ],
             [
-                'scope' => 'manipulate',
+                'scope' => 'citations.manipulate',
                 'permission' => 'citations.members.store',
             ],
             [
-                'scope' => 'manipulate',
+                'scope' => 'citations.manipulate',
                 'permission' => 'citations.members.destroy',
             ],
         ]);

--- a/database/seeds/PermissionScopeTableSeeder.php
+++ b/database/seeds/PermissionScopeTableSeeder.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use App\ApiPermission;
+
+class PermissionScopeTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $table = 'permission_scope';
+
+        DB::table($table)->delete();
+        DB::table($table)->insert([
+            // "import-scopus" scope includes all Scopus import permissions
+        	[
+        		'scope' => 'import-scopus',
+        		'permission' => 'citations.import.orcid',
+        	],
+            [
+                'scope' => 'import-scopus',
+                'permission' => 'citations.import.author',
+            ],
+
+            // "manipulate" scope includes all citation manipulation permissions
+            [
+                'scope' => 'manipulate',
+                'permission' => 'citations.store',
+            ],
+            [
+                'scope' => 'manipulate',
+                'permission' => 'citations.update',
+            ],
+            [
+                'scope' => 'manipulate',
+                'permission' => 'citations.destroy',
+            ],
+            [
+                'scope' => 'manipulate',
+                'permission' => 'citations.members.store',
+            ],
+            [
+                'scope' => 'manipulate',
+                'permission' => 'citations.members.destroy',
+            ],
+        ]);
+    }
+}

--- a/database/seeds/PermissionsTableSeeder.php
+++ b/database/seeds/PermissionsTableSeeder.php
@@ -1,0 +1,72 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use App\ApiPermission;
+
+class PermissionsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $table = (new ApiPermission())->getTable();
+
+        DB::table($table)->delete();
+        DB::table($table)->insert([
+            // retrieval citations are public but included for completeness
+            // in case we want to restrict public information to API keys
+            // as well
+        	[
+        		'system_name' => 'colleges.citations.index',
+        		'display_name' => 'Retrieve all citations for a college',
+        	],
+        	[
+        		'system_name' => 'departments.citations.index',
+        		'display_name' => 'Retrieve all citations for a department',
+        	],
+        	[
+        		'system_name' => 'citations.index',
+        		'display_name' => 'Retrieve all citations',
+        	],
+            [
+                'system_name' => 'citations.show',
+                'display_name' => 'Retrieve a single citation',
+            ],
+
+            // import permissions
+            [
+                'system_name' => 'citations.import.orcid',
+                'display_name' => 'Import citations from Scopus via ORCID',
+            ],
+            [
+                'system_name' => 'citations.import.author',
+                'display_name' => 'Import citations from Scopus via Scopus author ID',
+            ],
+
+            // citation manipulation permissions
+            [
+                'system_name' => 'citations.store',
+                'display_name' => 'Create a new citation',
+            ],
+            [
+                'system_name' => 'citations.update',
+                'display_name' => 'Modify an existing citation',
+            ],
+            [
+                'system_name' => 'citations.destroy',
+                'display_name' => 'Delete a citation',
+            ],
+            [
+                'system_name' => 'citations.members.store',
+                'display_name' => 'Associate a citation with a new individual',
+            ],
+            [
+                'system_name' => 'citations.members.destroy',
+                'display_name' => 'Dissociate an individual from a citation',
+            ],
+        ]);
+    }
+}

--- a/database/seeds/ScopesTableSeeder.php
+++ b/database/seeds/ScopesTableSeeder.php
@@ -21,11 +21,11 @@ class ScopesTableSeeder extends Seeder
         		'display_name' => 'Combination of all available scopes',
         	],
         	[
-        		'system_name' => 'import-scopus',
+        		'system_name' => 'citations.import.scopus',
         		'display_name' => 'Import citation data from Scopus',
         	],
         	[
-        		'system_name' => 'manipulate',
+        		'system_name' => 'citations.manipulate',
         		'display_name' => 'Create, modify, and delete citations',
         	],
         ]);

--- a/database/seeds/ScopesTableSeeder.php
+++ b/database/seeds/ScopesTableSeeder.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use App\ApiScope;
+
+class ScopesTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $table = (new ApiScope())->getTable();
+
+        DB::table($table)->delete();
+        DB::table($table)->insert([
+        	[
+        		'system_name' => 'all',
+        		'display_name' => 'Combination of all available scopes',
+        	],
+        	[
+        		'system_name' => 'import-scopus',
+        		'display_name' => 'Import citation data from Scopus',
+        	],
+        	[
+        		'system_name' => 'manipulate',
+        		'display_name' => 'Create, modify, and delete citations',
+        	],
+        ]);
+    }
+}


### PR DESCRIPTION
This adds API authorization functionality with a local relationship between keys, scopes, and the associated scope permissions in the API. There is no ability to register new API keys (though there is a seeder) since I do not wish to step on Luis' toes with the centralized API system.

I do, however, believe that the various services should maintain a record of a registered key and what it is able to do within its own service. An individual service would be able to make more-informed decisions about authorization in its own scope.

Much like everything else when working with web services, the authorization is driven by a middleware component that expects an `X-API-Key` request header to be sent along that contains a valid API key. There are also public-facing routes (any route name ending with `.index` or `.show`) that do not require API keys but will not fail if one is passed along.

Finally, there are database seeder classes that set-up the initial scaffolding for what scopes map to what permissions. The names of the permissions directly match with the names of the routes for simplicity (and since the period-notation is fairly common when it comes to naming scope permissions).

You can un-comment the line in `DatabaseSeeder.php` that runs the `KeyTableSeeder.php` class but take heed: it will destroy any existing records in that table and replace it with three new records. They're essentially just random data that gets hashed with SHA-1 for simplicity. I already seeded three keys on the staging DB environment for you to use for authorization testing.